### PR TITLE
backwards compatibility to 1.0a3 - using 'HOST.cfg' as default for HOST-VERSION.cfg

### DIFF
--- a/collective/hostout/hostout.py
+++ b/collective/hostout/hostout.py
@@ -186,7 +186,8 @@ class HostOut:
     def getHostoutFile(self):
         config = ConfigParser.ConfigParser()
         config.optionxform = str
-#        config.read([path])
+        # default all config settings from partname + ".cfg"
+        config.read(self.name+".cfg")
         if 'buildout' not in config.sections():
             config.add_section('buildout')
         files = []


### PR DESCRIPTION
In 1.0a3, the developer could add stanzas or parts to the .cfg file for the particular host to be deployed, and they would be sent to the deployment site unchanged if the config settings were not explicitly used by hostout.  Now that a HOST-VERSION.cfg file is sent, rather than HOST.cfg, those overrides are lost.  I've reimplemented it by defaulting the values in HOST-VERSION.cfg to HOST.cfg.  Note, that this file used to contain a [versions] section which MUST be deleted as it overrides the values as they are now sent.

Fixes [issue #8](https://github.com/collective/collective.hostout/issues/8)
